### PR TITLE
add psycopg2 package, for PostgreSQL support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN chmod a+x /start.sh \
         pwgen \
         py-pip \
         py-virtualenv \
+        py-psycopg2 \
         python \
         python-dev \
         sqlite \


### PR DESCRIPTION
Python needs the psycopg2 package in order to talk to a PostgreSQL database.
