### PR TITLE
dockerfile: use git instead of curl to get synapse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ RUN chmod a+x /start.sh ;\
         bash \
         coreutils \
         coturn \
-        curl \
         file \
         gcc \
         git \
@@ -61,7 +60,6 @@ RUN chmod a+x /start.sh ;\
         python-psycopg2 \
         python-virtualenv \
         sqlite \
-        unzip \
         zlib1g \
         zlib1g-dev \
     ; \
@@ -69,15 +67,13 @@ RUN chmod a+x /start.sh ;\
     pip install --upgrade python-ldap ;\
     pip install --upgrade lxml \
     ; \
-    curl -L https://github.com/matrix-org/synapse/archive/$BV_SYN.zip -o s.zip \
-    && unzip s.zip \
-    && cd /synapse-$BV_SYN \
+    git clone --branch $BV_SYN --depth 1 https://github.com/matrix-org/synapse.git \
+    && cd /synapse \
     && pip install --upgrade --process-dependency-links . \
     && GIT_SYN=$(git ls-remote https://github.com/matrix-org/synapse $BV_SYN | cut -f 1) \
     && echo "synapse: $BV_SYN ($GIT_SYN)" >> /synapse.version \
     && cd / \
-    && rm -rf synapse-$BV_SYN \
-    && rm s.zip \
+    && rm -rf /synapse \
     ; \
     apt-get remove -y \
         file \


### PR DESCRIPTION
there is a problem with using curl to download tags for versions from
github. the created directory from the archives have a different name
than the version tag itself.