### PR TITLE
Add some security to TLS setup of coturn server.

### DIFF
--- a/adds/start.sh
+++ b/adds/start.sh
@@ -17,6 +17,8 @@ generate_turn_key() {
 	echo "realm=turn.${SERVER_NAME}" >> "${filepath}"
 	echo "cert=/data/${SERVER_NAME}.tls.crt" >> "${filepath}"
 	echo "pkey=/data/${SERVER_NAME}.tls.key" >> "${filepath}"
+	echo "dh-file=/data/${SERVER_NAME}.tls.dh" >> "${filepath}"
+	echo "cipher-list=\"HIGH\"" >> "${filepath}"
 }
 
 generate_synapse_file() {


### PR DESCRIPTION
It is good idea to set a key for Diffie-Hellman algorithm because synapse allready create it. Default size of dh key in coturn is to small and volunerability scaner creates medium security issue in report.

Option "cipher-list" is openssl cipher list string. From the one hand setting it to "HIGH" improves security of TLS setup. From the other hand this can drop backward capability for old devices and operation systems without support of modern ciphers in openssl "HIGH" cipher set.