### PR TITLE
Remove Riot and separate turn and matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ services:
 
 script:
         # only docker build test
-        - docker build -t avhost/docker-matrix .
+        - docker build -t silvio/docker-matrix .

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ services:
 
 script:
         # only docker build test
-        - docker build -t silvio/docker-matrix .
+        - docker build -t avhost/docker-matrix .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # Maintainer
-MAINTAINER Andreas Peters <support@aventer.biz>
+MAINTAINER Silvio Fricke <silvio.fricke@gmail.com>
 
 # install homerserver template
 COPY adds/start.sh /start.sh
@@ -10,12 +10,6 @@ COPY adds/start.sh /start.sh
 COPY adds/supervisord-matrix.conf /conf/
 COPY adds/supervisord-turnserver.conf /conf/
 COPY adds/supervisord.conf /
-
-# startup configuration
-ENTRYPOINT ["/start.sh"]
-CMD ["start"]
-EXPOSE 8448
-VOLUME ["/data"]
 
 # Git branch to build from
 ARG BV_SYN=master
@@ -107,3 +101,11 @@ RUN set -ex \
     ; \
     apt-get autoremove -y ;\
     rm -rf /var/lib/apt/* /var/cache/apt/*
+
+EXPOSE 8448
+VOLUME ["/data"]
+
+# startup configuration
+ENTRYPOINT ["/start.sh"]
+CMD ["start"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # Maintainer
-MAINTAINER Silvio Fricke <silvio.fricke@gmail.com>
+MAINTAINER Andreas Peters <support@aventer.biz>
 
 # install homerserver template
 COPY adds/start.sh /start.sh

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -66,7 +66,6 @@ case $OPTION in
 		if [ "${TURN}" = "true" ]; then
 			echo "-=> start turn"
 		else
-			mv -f /conf/supervisord-turnserver.conf /conf/supervisord-turnserver.conf.deactivated
 			rm /conf/supervisord-turnserver.conf
 		fi
 
@@ -74,7 +73,6 @@ case $OPTION in
 		if [ "${MATRIX}" = "true" ]; then
 			echo "-=> start matrix"
 		else
-			mv -f /conf/supervisord-matrix.conf /conf/supervisord-matrix.conf.deactivated
 			rm /conf/supervisord-matrix.conf 
 		fi
 

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -63,27 +63,17 @@ configure_log_config() {
 
 case $OPTION in
 	"start")
-		if [ "${TURN}" eq "true" ]; then
+		if [ "${TURN}" = "true" ]; then
 			echo "-=> start turn"
-			if [ -f /conf/supervisord-turnserver.conf.deactivated ]; then
-				mv -f /conf/supervisord-turnserver.conf.deactivated /conf/supervisord-turnserver.conf
-			fi
 		else
-			if [ -f /conf/supervisord-turnserver.conf ]; then
-				mv -f /conf/supervisord-turnserver.conf /conf/supervisord-turnserver.conf.deactivated
-			fi
+			mv -f /conf/supervisord-turnserver.conf /conf/supervisord-turnserver.conf.deactivated
 		fi
 
 
-		if [ "${MATRIX}" eq "true" ]; then
+		if [ "${MATRIX}" = "true" ]; then
 			echo "-=> start matrix"
-			if [ -f /conf/supervisord-matrix.conf.deactivated ]; then
-				mv -f /conf/supervisord-matrix.conf.deactivated /conf/supervisord-matrix.conf
-			fi
 		else
-			if [ -f /conf/supervisord-matrix.conf ]; then
-				mv -f /conf/supervisord-matrix.conf /conf/supervisord-matrix.conf.deactivated
-			fi
+			mv -f /conf/supervisord-matrix.conf /conf/supervisord-matrix.conf.deactivated
 		fi
 
 		groupadd -r -g $MATRIX_GID matrix

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -74,14 +74,18 @@ case $OPTION in
 			fi
 		fi
 
-		echo "-=> start riot.im client"
-		(
-			if [ -f /data/vector.im.conf ] || [ -f /data/riot.im.conf ] ; then
-				echo "The riot web client is now handled via silvio/matrix-riot-docker"
-			fi
-		)
 
-		echo "-=> start matrix"
+		if [ -f /data/homeserver.yaml ]; then
+			echo "-=> start matrix"
+			if [ -f /conf/supervisord-matrix.conf.deactivated ]; then
+				mv -f /conf/supervisord-matrix.conf.deactivated /conf/supervisord-matrix.conf
+			fi
+		else
+			if [ -f /conf/supervisord-matrix.conf ]; then
+				mv -f /conf/supervisord-matrix.conf /conf/supervisord-matrix.conf.deactivated
+			fi
+		fi
+
 		groupadd -r -g $MATRIX_GID matrix
 		useradd -r -d /data -M -u $MATRIX_UID -g matrix matrix
 		chown -R $MATRIX_UID:$MATRIX_GID /data

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -63,7 +63,7 @@ configure_log_config() {
 
 case $OPTION in
 	"start")
-		if [ -f /data/turnserver.conf ]; then
+		if [ -n "${TURN}" ]; then
 			echo "-=> start turn"
 			if [ -f /conf/supervisord-turnserver.conf.deactivated ]; then
 				mv -f /conf/supervisord-turnserver.conf.deactivated /conf/supervisord-turnserver.conf
@@ -75,7 +75,7 @@ case $OPTION in
 		fi
 
 
-		if [ -f /data/homeserver.yaml ]; then
+		if [ -n "${MATRIX}" ]; then
 			echo "-=> start matrix"
 			if [ -f /conf/supervisord-matrix.conf.deactivated ]; then
 				mv -f /conf/supervisord-matrix.conf.deactivated /conf/supervisord-matrix.conf

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -63,7 +63,7 @@ configure_log_config() {
 
 case $OPTION in
 	"start")
-		if [ -n "${TURN}" ]; then
+		if [ "${TURN}" eq "true" ]; then
 			echo "-=> start turn"
 			if [ -f /conf/supervisord-turnserver.conf.deactivated ]; then
 				mv -f /conf/supervisord-turnserver.conf.deactivated /conf/supervisord-turnserver.conf
@@ -75,7 +75,7 @@ case $OPTION in
 		fi
 
 
-		if [ -n "${MATRIX}" ]; then
+		if [ "${MATRIX}" eq "true" ]; then
 			echo "-=> start matrix"
 			if [ -f /conf/supervisord-matrix.conf.deactivated ]; then
 				mv -f /conf/supervisord-matrix.conf.deactivated /conf/supervisord-matrix.conf

--- a/adds/start.sh
+++ b/adds/start.sh
@@ -67,6 +67,7 @@ case $OPTION in
 			echo "-=> start turn"
 		else
 			mv -f /conf/supervisord-turnserver.conf /conf/supervisord-turnserver.conf.deactivated
+			rm /conf/supervisord-turnserver.conf
 		fi
 
 
@@ -74,6 +75,7 @@ case $OPTION in
 			echo "-=> start matrix"
 		else
 			mv -f /conf/supervisord-matrix.conf /conf/supervisord-matrix.conf.deactivated
+			rm /conf/supervisord-matrix.conf 
 		fi
 
 		groupadd -r -g $MATRIX_GID matrix


### PR DESCRIPTION
Hi Silvio,

my pull is a little bit messy, sorry for that. :-(
Well, my idea was, to deactivate riot, and separate matrix and turn. That means, I will start a container with the env "TURN=true", and it will only start the turn process. The same with matrix (MATRIX=true)! The reason is very easy, I dont want to have a container with three (riot, matrix and turn) different processes. Every one should have his own container. :-) 

Regards,
Andreas