### PR TITLE
add relevant python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,9 @@ RUN set -ex \
     ; \
     pip install --upgrade pip ;\
     pip install --upgrade python-ldap ;\
+    pip install --upgrade pyopenssl ;\
+    pip install --upgrade enum34 ;\
+    pip install --upgrade ipaddress ;\
     pip install --upgrade lxml ;\
     pip install --upgrade supervisor \
     ; \


### PR DESCRIPTION
After running `pip install --upgrade --force "pyopenssl>=0.14"` pip installs the following packages that weren't installed in the container during building:  
`enum34 ipaddress pyopenssl`

I added a pip install for these packages, this should fix #41 

I verified this myself, though it may be wise for someone else to verify as well (I did test to the point of actually  running the matrix server in docker this time, so I see no reason it wouldn't work).

[edit] come to think of it, it's possible that the error technically is in [synapse dependencies](https://github.com/matrix-org/synapse/blob/6c1bb1601e43c89637ae5bd8720c255646ca8141/synapse/python_dependencies.py), it may have to include one or more of the packages I added to the install.