### PR TITLE
fix link to matrix.org

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ VoIP communication server.
 
 The riot.im web client has now his own docker file at [github].
 
-[matrix]: matrix.org
+[matrix]: https://matrix.org
 [github]: https://github.com/silvio/matrix-riot-docker
 
 # Contribution


### PR DESCRIPTION
The link to matrix.org in the readme missed https:// which is why it didn't work. (links to https://github.com/silvio/docker-matrix/blob/master/matrix.org which gives a 404).