### PR TITLE
explain use for self signed certificate

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,9 +45,8 @@ generated homeserver.yaml file.
 Please read the synapse [readme file] about configuration settings.
 [readme file]: https://github.com/matrix-org/synapse/blob/master/README.rst
 
-To get the things done, "generate" will create a own self-signed certificate.
-
-> This needs to be changed for production usage.
+To get the things done, "generate" will create a self-signed certificate, which
+can be used for federation.
 
 Example:
 


### PR DESCRIPTION
The self signed certificate can actually be used (the recommend setup uses the cert for federation) so the readme should reflect that.  
I also removed the line "this should be changed for production use" because that's not necessarily true.